### PR TITLE
Add `--no-debug-info` to apktool

### DIFF
--- a/apkdiff.py
+++ b/apkdiff.py
@@ -78,7 +78,7 @@ def main():
 
 def apktoolit(file, dir):
     print("Running apktool against '" + format(file, bcolors.OKBLUE) + "'")
-    call(["apktool", "d", "-o", dir, file], stdout=open(os.devnull, 'w'), stderr=STDOUT)
+    call(["apktool", "d", "--no-debug-info", "-o", dir, file], stdout=open(os.devnull, 'w'), stderr=STDOUT)
     print("[" + format("OK", bcolors.OKGREEN) + "]")
 
 def compare(folder1, folder2):


### PR DESCRIPTION
From https://ibotpeaches.github.io/Apktool/documentation/

> `--no-debug-info`
> Prevents baksmali from writing out debug info (.local, .param, .line, etc). Preferred to use if you are comparing smali from the same APK of different versions. The line numbers and debug will change among versions, which can make DIFF reports a pain.