### PR TITLE
Various improvements

### DIFF
--- a/apkdiff.py
+++ b/apkdiff.py
@@ -12,7 +12,6 @@ import argparse
 import difflib
 import tempfile
 
-at = "at/"
 ignore = ".*(align|apktool.yml|pak|MF|RSA|SF|bin|so)"
 count = 0
 args = None
@@ -40,7 +39,7 @@ def main():
     parser.add_argument('-m', '--meld', action='store_true', help='Open meld to compare directories after.')
     parser.add_argument('-o', '--output', default=os.path.join(tempfile.gettempdir(), 'apkdiff'), help='The location to output the extracted files to.')
     parser.add_argument('-u', '--unique', action='store_true', help='By default, only differences in common files are printed. If -u is enabled, unique files are printed too')
-
+    
     global args
     args = parser.parse_args()
 

--- a/apkdiff.py
+++ b/apkdiff.py
@@ -6,9 +6,11 @@ import zipfile
 from filecmp import *
 from subprocess import call, STDOUT
 import shutil
+import glob
 import re
 import argparse
 import difflib
+import tempfile
 
 at = "at/"
 ignore = ".*(align|apktool.yml|pak|MF|RSA|SF|bin|so)"
@@ -19,6 +21,7 @@ d = difflib.Differ()
 class bcolors:
     OKBLUE = '\033[94m'
     OKGREEN = '\033[92m'
+    OKORANGE = '\033[93m'
     FAIL = '\033[91m'
 
 def format(string, col):
@@ -35,8 +38,9 @@ def main():
     parser.add_argument('apk2', metavar='apk2', help='Location of the second APK.')
     parser.add_argument('-c', '--cleanup', action='store_true', help='Remove all extracted files after computation.')
     parser.add_argument('-m', '--meld', action='store_true', help='Open meld to compare directories after.')
-    parser.add_argument('-o', '--output', default="/tmp/apkdiff/", help='The location to output the extracted files to.')
-    
+    parser.add_argument('-o', '--output', default=os.path.join(tempfile.gettempdir(), 'apkdiff'), help='The location to output the extracted files to.')
+    parser.add_argument('-u', '--unique', action='store_true', help='By default, only differences in common files are printed. If -u is enabled, unique files are printed too')
+
     global args
     args = parser.parse_args()
 
@@ -48,23 +52,20 @@ def main():
     folderExists(args.output, True)
 
     # Individual folders for each APK.
-    temp1 = args.output + "1/"
-    temp2 = args.output + "2/"
+    temp1 = os.path.join(args.output, "1/")
+    temp2 = os.path.join(args.output, "2/")
 
-    # Extracted code + resources from Apktool.
-    at1 = temp1 + at
-    at2 = temp2 + at
 
     folderExists(temp1, True)
     folderExists(temp2, True)
 
-    extract(args.apk1, temp1)
-    extract(args.apk2, temp2)
+    apktoolit(args.apk1, temp1)
+    apktoolit(args.apk2, temp2)
 
-    apktoolit(args.apk1, at1)
-    apktoolit(args.apk2, at2)
+    mergesmalifolders(temp1)
+    mergesmalifolders(temp2)
 
-    compare(at1, at2)
+    compare(os.path.join(temp1, "smali"), os.path.join(temp2, "smali"), args.unique)
 
     # Remove all the stuff we have created.
     if args.cleanup and os.path.exists(temp1):
@@ -74,28 +75,80 @@ def main():
         shutil.rmtree(temp2)
 
     if args.meld:
-        call(["meld", at1, at2])
+        call(["meld", temp1, temp2])
 
 def apktoolit(file, dir):
     print("Running apktool against '" + format(file, bcolors.OKBLUE) + "'")
-    call(["apktool", "d", "--no-debug-info", "-o", dir, file], stdout=open(os.devnull, 'w'), stderr=STDOUT, shell=True)
+    call(["apktool", "d", "-r", "-f", "-o", dir, file], stdout=open(os.devnull, 'w'), stderr=STDOUT)
     print("[" + format("OK", bcolors.OKGREEN) + "]")
 
-def compare(folder1, folder2):
+
+def mergesmalifolders(folder):
+    print("Merging additional smali folders")
+    target = os.path.join(folder, "smali")
+    for name in glob.glob(folder + "smali_classes*"):
+        print("\t" + name + " > " + target)
+        mergefolders(name, target)
+    print("[" + format("OK", bcolors.OKGREEN) + "]")
+
+def mergefolders(root_src_dir, root_dst_dir):
+    for src_dir, dirs, files in os.walk(root_src_dir):
+        dst_dir = src_dir.replace(root_src_dir, root_dst_dir, 1)
+        if not os.path.exists(dst_dir):
+            os.makedirs(dst_dir)
+        for file_ in files:
+            src_file = os.path.join(src_dir, file_)
+            dst_file = os.path.join(dst_dir, file_)
+            if os.path.exists(dst_file):
+                os.remove(dst_file)
+            shutil.move(src_file, dst_dir)
+
+def compare(folder1, folder2, printunique):
     print("")
     compared = dircmp(folder1, folder2)
-    report_full_closure(compared)
+    uniqueleft, uniqueright = report_full_closure(compared)
     print("\n\t" + format(str(count), bcolors.OKBLUE) + " files are different.\n")
 
-def report_full_closure(self):
-    for name in self.diff_files:
+    if printunique:
+        if uniqueleft:
+            print("[" + format("Only in apk1", bcolors.OKORANGE)  + "] ")
+            for uniquefolder in uniqueleft:
+                print("\t"+uniquefolder)
+            print("[" + format("{} unique files in apk1".format(len(uniqueleft)), bcolors.OKORANGE)  + "] ")
+        else:
+            print("[" + format("No unique files in apk1", bcolors.OKORANGE)  + "] ")
+        if uniqueright:
+            print("[" + format("Only in apk2", bcolors.OKORANGE)  + "] ")
+            for uniquefolder in uniqueright:
+                print("\t"+uniquefolder)
+            print("[" + format("{} unique files in apk2".format(len(uniqueright)), bcolors.OKORANGE)  + "] ")
+        else:
+            print("[" + format("No unique files in apk2", bcolors.OKORANGE)  + "] ")
 
+def getfiles(base, folders, root):
+    f = []
+
+    for folder in folders:
+        for localroot, subdirs, files in os.walk(os.path.join(base, folder)):
+            for file in files:
+                f.append(os.path.relpath(os.path.join(localroot, file), root))
+    return f
+
+
+def report_full_closure(self, uniqueleft = [], uniqueright=[], rootcmp=None):
+
+    if not rootcmp:
+        rootcmp = self
+
+    uniqueleft += getfiles(self.left, self.left_only, rootcmp.left)
+    uniqueright += getfiles(self.right, self.right_only, rootcmp.right)
+    for name in self.diff_files:
         if not re.match(ignore, name):
             print("[" + format(name, bcolors.OKGREEN)  + "] " + 
                     format(self.left.replace(args.output + "1",""), bcolors.OKBLUE))
 
-            content1 = reader(self.left + "/" + name).splitlines(1)
-            content2 = reader(self.right + "/" + name).splitlines(1)
+            content1 = reader(os.path.join(self.left, name)).splitlines(1)
+            content2 = reader(os.path.join(self.right, name)).splitlines(1)
 
             diff = difflib.unified_diff(content1, content2)
             tidy(list(diff))
@@ -104,7 +157,10 @@ def report_full_closure(self):
             count += 1
 
     for sd in self.subdirs.values():
-        report_full_closure(sd)
+        report_full_closure(sd, uniqueleft, uniqueright, rootcmp)
+    
+    return uniqueleft, uniqueright
+
 
 def tidy(lines):
     sorted = ""
@@ -134,12 +190,6 @@ def exists(file):
     if not os.path.isfile(file):
         print(format("'{}' does not exist.".format(file), bcolors.FAIL))
         exit(0)
-
-def extract(apk, dir):
-    zipfi = zipfile.ZipFile(apk, 'r')
-    zipfi.extract("classes.dex", dir)
-    zipfi.close()
-    print("Extracted '" + format("classes.dex", bcolors.OKBLUE) + "' from '" + format(apk, bcolors.OKBLUE) + "'.")
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
There are a few issues with the current version:
* It's broken due to https://github.com/daniellockyer/apkdiff/pull/7, as indicated by https://github.com/daniellockyer/apkdiff/issues/8 
* It only compares files in the main smali dir. Many applications are multi-dex which means they also have multiple smali directories
* The tool only compares files that exist both in apk1 and apk2

So I made a few modifications:
* Removed shell=True as that breaks the tool on most OS's
* Added a -u optional argument that will list unique files
* Removed the unzipping of classes.dex, as that isn't necessary. It's also not complete (since there can be classesX.dex) and classes.dex isn't used anywhere
* Skipped decoding of resources by apktool. This is something that can give errors when analysing malware, and since the tool is only focused on code, we don't need it
* Added code to merge all smali folders into one smali folder
* Some python updates (using os.path.join rather than concatenation, getting a system temp dir instead of hardcoding, ...)

